### PR TITLE
Adds environment set up; Adds executor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <br/>
 
+[![Build Status](https://travis-ci.org/cirocosta/cr.svg?branch=master)](https://travis-ci.org/cirocosta/cr)
 
 ### Overview
 

--- a/examples/environment.yaml
+++ b/examples/environment.yaml
@@ -1,0 +1,18 @@
+Env:
+  WORD: 'BAZ'
+
+Jobs:
+  - Id: 'SayFoo'
+    Run: 'echo $WORD'
+    Env:
+      WORD: 'foo'
+
+  - Id: 'SayBaz'
+    Run: 'echo $WORD'
+    DependsOn: [ 'SayFoo' ]
+
+  - Id: 'SayCaz'
+    Run: 'echo $SAY'
+    Env:
+      SAY: 'CAZ'
+    DependsOn: [ 'SayFoo' ]

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -22,10 +23,16 @@ func (e *Execution) init(ctx context.Context) (err error) {
 		return
 	}
 
+	allEnv := os.Environ()
+	for k, v := range e.Env {
+		allEnv = append(allEnv, k+"="+v)
+	}
+
 	e.cmd = exec.CommandContext(ctx, e.Argv[0], e.Argv[1:]...)
 	e.cmd.Stdout = e.Stdout
 	e.cmd.Stderr = e.Stderr
 	e.cmd.Dir = e.Directory
+	e.cmd.Env = allEnv
 
 	return
 }

--- a/lib/executor.go
+++ b/lib/executor.go
@@ -165,6 +165,16 @@ func (e *Executor) RunJob(ctx context.Context, j *Job) (err error) {
 
 	j.Directory = directory
 
+	if len(e.config.Env) > 0 {
+		if j.Env == nil || len(j.Env) == 0 {
+			j.Env = e.config.Env
+		} else {
+			for k, v := range e.config.Env {
+				j.Env[k] = v
+			}
+		}
+	}
+
 	switch j.Run {
 	case "":
 		goto END
@@ -188,6 +198,7 @@ func (e *Executor) RunJob(ctx context.Context, j *Job) (err error) {
 		Stdout:    io.MultiWriter(stdout...),
 		Stderr:    io.MultiWriter(stderr...),
 		Directory: j.Directory,
+		Env:       j.Env,
 	}
 
 	if e.config.OnJobStatusChange != nil {

--- a/lib/executor.go
+++ b/lib/executor.go
@@ -97,6 +97,11 @@ func (e *Executor) Execute(ctx context.Context) (err error) {
 }
 
 func (e *Executor) ResolveJobDirectory(j *Job, renderState *RenderState) (res string, err error) {
+	if j == nil || renderState == nil {
+		err = errors.Errorf("job and renderState must be non-nil")
+		return
+	}
+
 	switch j.Directory {
 	case "":
 		res = "."

--- a/lib/executor_test.go
+++ b/lib/executor_test.go
@@ -61,3 +61,109 @@ func TestResolveJobDirectory(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveEnvironment(t *testing.T) {
+	var testCases = []struct {
+		desc        string
+		job         *Job
+		globalEnv   map[string]string
+		state       *RenderState
+		expected    map[string]string
+		shouldError bool
+	}{
+		{
+			desc:        "nil",
+			shouldError: true,
+		},
+		{
+			desc:     "empty environment uses none",
+			job:      &Job{},
+			state:    &RenderState{},
+			expected: map[string]string{},
+		},
+		{
+			desc: "custom job environment",
+			job: &Job{
+				Env: map[string]string{"FOO": "BAR"},
+			},
+			state:    &RenderState{},
+			expected: map[string]string{"FOO": "BAR"},
+		},
+		{
+			desc: "custom job environment with global",
+			job: &Job{
+				Env: map[string]string{"FOO": "BAR"},
+			},
+			globalEnv: map[string]string{"CAZ": "BAZ"},
+			state:     &RenderState{},
+			expected:  map[string]string{"FOO": "BAR", "CAZ": "BAZ"},
+		},
+		{
+			desc:      "just global",
+			job:       &Job{},
+			globalEnv: map[string]string{"CAZ": "BAZ"},
+			state:     &RenderState{},
+			expected:  map[string]string{"CAZ": "BAZ"},
+		},
+		{
+			desc: "job overriding global",
+			job: &Job{
+				Env: map[string]string{"CAZ": "LOL"},
+			},
+			globalEnv: map[string]string{"CAZ": "BAZ"},
+			state:     &RenderState{},
+			expected:  map[string]string{"CAZ": "LOL"},
+		},
+		{
+			desc: "custom job environment with templating",
+			job: &Job{
+				Env: map[string]string{"FOO": "{{ .Jobs.Job1.Output }}"},
+			},
+			state: &RenderState{
+				Jobs: map[string]*Job{
+					"Job1": {Output: "lol"},
+				},
+			},
+			expected: map[string]string{"FOO": "lol"},
+		},
+		{
+			desc:      "global environment with templating",
+			globalEnv: map[string]string{"CAZ": "{{ .Jobs.Job1.Output }}"},
+			job:       &Job{},
+			state: &RenderState{
+				Jobs: map[string]*Job{
+					"Job1": {Output: "lol"},
+				},
+			},
+			expected: map[string]string{"CAZ": "lol"},
+		},
+	}
+
+	var (
+		err    error
+		actual map[string]string
+
+		e = Executor{
+			config: &Config{},
+		}
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			e.config.Env = tc.globalEnv
+
+			actual, err = e.ResolveJobEnv(tc.job, tc.state)
+			if tc.shouldError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expected), len(actual))
+
+			for k, _ := range tc.expected {
+				assert.Equal(t, tc.expected[k], actual[k])
+			}
+		})
+	}
+}

--- a/lib/executor_test.go
+++ b/lib/executor_test.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveJobDirectory(t *testing.T) {
+	var testCases = []struct {
+		desc        string
+		job         *Job
+		state       *RenderState
+		expected    string
+		shouldError bool
+	}{
+		{
+			desc:        "nil",
+			shouldError: true,
+		},
+		{
+			desc: "empty directory uses default",
+			job: &Job{
+				Directory: "",
+			},
+			state:    &RenderState{},
+			expected: ".",
+		},
+		{
+			desc: "templated directory",
+			job: &Job{
+				Directory: "/{{ .Jobs.Job1.Output }}",
+			},
+			state: &RenderState{
+				Jobs: map[string]*Job{
+					"Job1": {Output: "lol"},
+				},
+			},
+			expected: "/lol",
+		},
+	}
+
+	var (
+		err    error
+		actual string
+
+		e = Executor{}
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual, err = e.ResolveJobDirectory(tc.job, tc.state)
+			if tc.shouldError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/lib/templater.go
+++ b/lib/templater.go
@@ -8,12 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RenderState encapsulates the state that can
-// be used when templating a given field.
-type RenderState struct {
-	Jobs map[string]*Job
-}
-
 var (
 	FuncMap = template.FuncMap{
 		"env": os.Getenv,

--- a/lib/types.go
+++ b/lib/types.go
@@ -21,6 +21,12 @@ type Execution struct {
 	cmd *exec.Cmd
 }
 
+// RenderState encapsulates the state that can
+// be used when templating a given field.
+type RenderState struct {
+	Jobs map[string]*Job
+}
+
 // Config aggregates all the types of cofiguration
 // that can be retrieved from a `.cr.yml` configuration
 // file.

--- a/lib/types.go
+++ b/lib/types.go
@@ -11,6 +11,7 @@ import (
 type Execution struct {
 	Argv      []string
 	ExitCode  int
+	Env       map[string]string
 	Directory string
 	Stdout    io.Writer
 	Stderr    io.Writer

--- a/lib/types.go
+++ b/lib/types.go
@@ -57,7 +57,7 @@ type Runtime struct {
 
 	// LogsDirectory indicates the path to the directory where logs
 	// are sent to.
-	LogsDirectory string `arg:"help:path to the directory where logs are sent to" yaml:"LogsDirectory"`
+	LogsDirectory string `arg:"--logs-directory,help:path to the directory where logs are sent to" yaml:"LogsDirectory"`
 
 	// Stdout indicates whether the execution logs should be pipped
 	// to stdout or not.

--- a/main.go
+++ b/main.go
@@ -63,6 +63,14 @@ func main() {
 		ui.WriteActivity(a)
 	}
 
+	if cfg.Runtime.LogsDirectory == "" {
+		cfg.Runtime.LogsDirectory = args.LogsDirectory
+	}
+
+	if args.Stdout {
+		cfg.Runtime.Stdout = true
+	}
+
 	executor, err := lib.New(&cfg)
 	must(err)
 

--- a/main.go
+++ b/main.go
@@ -63,8 +63,6 @@ func main() {
 		ui.WriteActivity(a)
 	}
 
-	cfg.Runtime = args.Runtime
-
 	executor, err := lib.New(&cfg)
 	must(err)
 


### PR DESCRIPTION
closes #3 
closes #6 

Aside from covering those issues, it also makes possible to perform templating on any of those fields. For instance: 

```yaml
Jobs:
  - Id: 'Job1'
    CaptureOutput: true
    Run: 'echo lol'

  - Id: 'Job2'
    CaptureOutput: true
    Env: 
      FOO: '{{ .Jobs.Job1.Output }}'
    Run: 'echo $FOO'
    DependsOn: [ 'Job1' ] 
```

would lead to 

```
lol
lol
```

---

Sample execution:

```yaml
Env:
  WORD: 'BAZ'

Jobs:
  - Id: 'SayFoo'
    Run: 'echo $WORD'
    Env:
      WORD: 'foo'

  - Id: 'SayBaz'
    Run: 'echo $WORD'
    DependsOn: [ 'SayFoo' ]

  - Id: 'SayCaz'
    Run: 'echo $SAY'
    Env:
      SAY: 'CAZ'
    DependsOn: [ 'SayFoo' ]

```

leads to

```sh
cr --file ./examples/environment.yaml --stdout=true

	Starting execution.

	Logs directory:	/tmp
	
SayFoo	status=STARTED	start=21:22:55
foo
SayFoo	status=SUCCESS	start=21:22:55	elapsed=4.176744ms
SayBaz	status=STARTED	start=21:22:55
SayCaz	status=STARTED	start=21:22:55
BAZ
SayBaz	status=SUCCESS	start=21:22:55	elapsed=4.781021ms
CAZ
SayCaz	status=SUCCESS	start=21:22:55	elapsed=5.706108ms
```